### PR TITLE
Share a Note

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,2 +1,2 @@
-class NotesController
+class NotesController < ApplicationController
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,0 +1,2 @@
+class NotesController
+end

--- a/app/views/notes/create.html.erb
+++ b/app/views/notes/create.html.erb
@@ -1,0 +1,1 @@
+<%= params.fetch(:content) %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,0 +1,3 @@
+<a href="#">
+  Share a Note
+</a>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,3 +1,3 @@
-<a href="/notes/new">
+<a href="<%= new_note_path %>">
   Share a Note
 </a>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,3 +1,3 @@
-<a href="#">
+<a href="/notes/new">
   Share a Note
 </a>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(url: "/notes", method: :post, local: true) do |form| %>
-  <label for="content">Message</label>
+  <%= form.label(:content, "Message") %>
   <%= form.text_area(:content) %>
 
   <button>Share</button>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,0 +1,2 @@
+<label for="content">Message</label>
+<textarea id="content"></textarea>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,6 +1,6 @@
-<%= form_with(url: "/notes", method: :post, local: true) do %>
+<%= form_with(url: "/notes", method: :post, local: true) do |form| %>
   <label for="content">Message</label>
-  <textarea id="content" name="content"></textarea>
+  <%= form.text_area(:content) %>
 
   <button>Share</button>
 <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,6 +1,6 @@
-<form action="/notes" method="post">
+<%= form_tag "/notes", method: :post do %>
   <label for="content">Message</label>
   <textarea id="content" name="content"></textarea>
 
   <button>Share</button>
-</form>
+<% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,2 +1,4 @@
 <label for="content">Message</label>
 <textarea id="content"></textarea>
+
+<button>Share</button>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: "/notes", method: :post, local: true) do |form| %>
+<%= form_with(url: notes_path, method: :post, local: true) do |form| %>
   <%= form.label(:content, "Message") %>
   <%= form.text_area(:content) %>
 

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag "/notes", method: :post do %>
+<%= form_with(url: "/notes", method: :post, local: true) do %>
   <label for="content">Message</label>
   <textarea id="content" name="content"></textarea>
 

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,6 +1,6 @@
 <form action="/notes" method="post">
   <label for="content">Message</label>
-  <textarea id="content"></textarea>
+  <textarea id="content" name="content"></textarea>
 
   <button>Share</button>
 </form>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,4 +1,6 @@
-<label for="content">Message</label>
-<textarea id="content"></textarea>
+<form action="/notes" method="post">
+  <label for="content">Message</label>
+  <textarea id="content"></textarea>
 
-<button>Share</button>
+  <button>Share</button>
+</form>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -2,5 +2,5 @@
   <%= form.label(:content, "Message") %>
   <%= form.text_area(:content) %>
 
-  <button>Share</button>
+  <%= form.submit("Share") %>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :notes, only: [:new, :create]
 
-  get "/", controller: "notes", action: "index", as: "root"
+  root controller: "notes", action: "index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get "/", controller: "notes", action: "index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get "/notes/new", controller: "notes", action: "new"
+
   get "/", controller: "notes", action: "index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "/notes/new", controller: "notes", action: "new", as: "new_note"
-  post "/notes", controller: "notes", action: "create"
+  post "/notes", controller: "notes", action: "create", as: "notes"
 
   get "/", controller: "notes", action: "index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   resources :notes, only: [:new, :create]
 
-  get "/", controller: "notes", action: "index"
+  get "/", controller: "notes", action: "index", as: "root"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  get "/notes/new", controller: "notes", action: "new", as: "new_note"
-  post "/notes", controller: "notes", action: "create", as: "notes"
+  resources :notes, only: [:new, :create]
 
   get "/", controller: "notes", action: "index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  get "/notes/new", controller: "notes", action: "new"
+  get "/notes/new", controller: "notes", action: "new", as: "new_note"
   post "/notes", controller: "notes", action: "create"
 
   get "/", controller: "notes", action: "index"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   get "/notes/new", controller: "notes", action: "new"
+  post "/notes", controller: "notes", action: "create"
 
   get "/", controller: "notes", action: "index"
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/test/system/user_shares_a_message_test.rb
+++ b/test/system/user_shares_a_message_test.rb
@@ -1,9 +1,14 @@
 require "application_system_test_case"
 
 class UserSharesAMessageTest < ApplicationSystemTestCase
-  # test "visiting the index" do
-  #   visit user_shares_a_messages_url
-  #
-  #   assert_selector "h1", text: "UserSharesAMessage"
-  # end
+  test "visiting the index" do
+    content = "Hello, World!"
+
+    visit "/"
+    click_on "Share a Note"
+    fill_in "Message", with: content
+    click_on "Share"
+
+    assert_text content
+  end
 end

--- a/test/system/user_shares_a_message_test.rb
+++ b/test/system/user_shares_a_message_test.rb
@@ -1,0 +1,9 @@
+require "application_system_test_case"
+
+class UserSharesAMessageTest < ApplicationSystemTestCase
+  # test "visiting the index" do
+  #   visit user_shares_a_messages_url
+  #
+  #   assert_selector "h1", text: "UserSharesAMessage"
+  # end
+end

--- a/test/system/user_shares_a_message_test.rb
+++ b/test/system/user_shares_a_message_test.rb
@@ -4,7 +4,7 @@ class UserSharesAMessageTest < ApplicationSystemTestCase
   test "visiting the index" do
     content = "Hello, World!"
 
-    visit "/"
+    visit root_path
     click_on "Share a Note"
     fill_in "Message", with: content
     click_on "Share"


### PR DESCRIPTION
Closes #2 :

When I have a thought,
I want to share a message,
So that I can put me ideas into the world

[card]: https://github.com/seanpdoyle/prix-fixe/projects/1#card-20484715

---

Add `UserSharesAMessageTest`

This commit includes the output of:

```bash
% rails generate system_test user_shares_a_message
```

---

Add a failing system test

https://github.com/seanpdoyle/prix-fixe/projects/1#card-20484715

When I have a thought,
I want to share a message,
So that I can put me ideas into the world

---

This commit adds content to the scaffolded `UserSharesAMessageTest`
block named `"visiting the index"`.

Writing a test first, before the corresponding implementation is an
integral part of [Test-Driven Development][tdd].

Writing a System Test before other tests is an integral part of [testing
an application from the Outside In][outside-in].

Our test is visually separated into blocks by newlines. It resembles a
[Four Phase Test][four-phase-test].

1. First, we'll declare our test data in the test's Setup Phase. For now
  the only test data that we'll need is a String representing the new
  Note's `content` attribute.

2. Next, we declare the Exercise Phase. This phase will interact with the
  feature from a browser. Thinking in abstract terms, the exercise phase
  will:

  * visit the application's root
  * click on a link to create a new Note
  * fill in a form field with the `content` of our Note
  * click on a button to submit the new Note

  Each of these steps corresponds directly to a [Capybara-provided
  method][capybara-dsl]. The corresponding `<form>` fields' elements'
  label text is provided as an argument to each method call in this
  exercise phase.

3. Next, we declare the Verify Phase. During this phase, our test will
  ensure that the behavior it expects aligns with the actual behavior.
  To do so, we assert that the `content` appears on the page by calling
  [`assert_text`][assert_text]. In this case, the presence of the
  `content` on the page is a [Good Enough :tm: indicator][abstraction]
  that the form submission was successful, and the Note was persisted
  well enough to be served to a user in a subsequent HTTP request.

4. Finally, there is a Teardown Phase. The Teardown Phase is different
  from the others in that Rails' system test harness handles the
  teardown steps on our behalf. For instance, tests that set
  `.use_transactional_tests = true` will configure the test to be a
  [Transactional Test][transactional-test], and will be executed within
  a [SQL Transaction][sql-transaction]. In practice, this means that
  records created within a test will only exist within the bounds of that
  test block. For now, our test suite's teardown demands are limited to
  the database, but if future needs arose, they could be addressed with
  our [test harness' hook system][setup-and-teardown].

When we execute the test, it fails:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionController::RoutingError: No route matches [GET] "/"
```

This error informs us that our application does not know how to route or
respond to `GET /` HTTP requests. Our next step will be resolve that
error.

[tdd]: https://thoughtbot.com/upcase/fundamentals-of-tdd
[outside-in]: https://thoughtbot.com/blog/testing-from-the-outsidein
[four-phase-test]: https://thoughtbot.com/blog/four-phase-test
[capybara-dsl]: https://www.rubydoc.info/github/teamcapybara/capybara/master#The_DSL
[assert_text]: https://www.rubydoc.info/github/jnicklas/capybara/Capybara/Node/Matchers#assert_text-instance_method
[abstraction]: https://thoughtbot.com/blog/acceptance-tests-at-a-single-level-of-abstraction
[transactional-test]: https://api.rubyonrails.org/v5.2/classes/ActiveRecord/FixtureSet.html#class-ActiveRecord::FixtureSet-label-Transactional+Tests
[setup-and-teardown]: https://api.rubyonrails.org/v5.2/classes/ActiveSupport/Testing/SetupAndTeardown.html
[sql-transaction]: https://www.sqlite.org/lang_transaction.html

---

Declare `GET "/"` route

In order to access the `GET /` route in `UserSharesAMessageTest`,
declare a route using the [`get` route helper][get], which delegates its
arguments to the underlying [`match` route helper][match], in order to
handle requests made with the [`GET` HTTP Verb][get-verb].

The [`get` declaration accepts options][options]. The `controller:`
option instructs the router to route requests with the `GET` verb and
the `"/"` path to the controller name with the corresponding name.

In this commit's case, `controller: "notes"` corresponds to the
`NotesController`.

Another option the `get` helper accepts is `action:`. The value assigned
to the `action:` key instructs the router to route requests that match
the criteria to the corresponding controller's instance method.

In this commit's case, `action: "index"` corresponds to the
`NotesController#index` instance method.

Once the route exists, the request made in the test yields a new error:

```
Error:
UserSharesAMessagesTest#test_visiting_the_index:
ActionController::RoutingError: uninitialized constant NotesController
Did you mean?  ActionController
```

[get]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/HttpHelpers.html#method-i-get
[match]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-match
[get-verb]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/GET
[options]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-match-label-Options

---

Declare `NotesController`

This commit responds to the previous error:

```
Error:
UserSharesAMessagesTest#test_visiting_the_index:
ActionController::RoutingError: uninitialized constant NotesController
Did you mean?  ActionController
```

To resolve that error, declare a `NotesController` class in
the `app/controllers` directory.

When we execute our test suite, a new error is raised:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
DRb::DRbRemoteError: undefined method `make_response!' for NotesController:Class (NoMethodError)
```

---

Extend from `ApplicationController`

This commit is in response to the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
DRb::DRbRemoteError: undefined method `make_response!' for NotesController:Class (NoMethodError)
```

By extending the project's
[`ApplicationController`][application_controller], the `NotesController`
gains access to
[`ActionController::Base.make_response!`][make_response].

When the tests are run again, a new error is raised:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'index' could not be found for NotesController
```

[make_response]: https://api.rubyonrails.org/v5.2/classes/ActionController/Base.html#method-c-make_response-21

---

Declare `app/views/notes/index.html.erb`

This commit introduces code in response to an error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'index' could not be found for NotesController
```

To declare an "action", a controller that extends from
`ActionController::Base` can either:

* define an instance method that corresponds to the action (in this
  case, `index`)
* declare a view file named after the action in the directory that
  corresponds to the controller name (in this case,
  `notes/index.html.erb`)

If a method that corresponds to the action does not exist, Rails will
automatically [infer which template to render][template].

This commit relies on that convention.

When running the tests, a new error is raised:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find link or button "Share a Note"
    test/system/user_shares_a_message_test.rb:8:in `block in <class:UserSharesAMessageTest>'
```

[template]: https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#rendering-by-default-convention-over-configuration-in-action

---

Render `<a>` containing `"Share a Note"`

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find link or button "Share a Note"
    test/system/user_shares_a_message_test.rb:8:in `block in <class:UserSharesAMessageTest>'
```

The [`click_on` Capybara helper][click_on] (an alias of
`click_link_or_button`) expects the corresponding element to be an `<a>`
element or a `<button>` element. The test is invoking `click_on` with
`"Share a Note"` as an argument. According to the documentation, the
[`click_link`][click_link]:

> Finds a link by `id`, `Capybara.test_id` attribute, text or title

To advance our test to the next failure, we declare an `<a>` element
with `"Share a Note"` as its text. Since our system tests are executed
within the context of a web browser, the `<a>` element declares
[`href="#"`][href] to ensure that it is interactive and clickable.

When we run the system test again, it raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find field "Message"
    test/system/user_shares_a_message_test.rb:9:in `block in <class:UserSharesAMessageTest>'
```

[click_on]: https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Actions#click_link_or_button-instance_method
[click_link]: https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Actions#click_link-instance_method
[href]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href

---

Link to `"/"`

This commit deviates from purely reactive, test-driven code changes.

The previous error was:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find field "Message"
    test/system/user_shares_a_message_test.rb:9:in `block in <class:UserSharesAMessageTest>'
```

The previous change to `click_on "Share a Note"` exercised an [`<a>`
element with an empty fragment (`href="#"`)][empty-fragment]. When
clicked, the browser does not navigate to a separate page.

If this change were motivated purely by test failures and error
messages, we'd need to add an element to the `notes#index` page with
`"Message"`.

However, since the call to `click_on "Share a Note"` didn't navigate to
a new page, introducing a change that navigates to a "new" page shortens
the path between our current behavior and our desired behavior.

Instead of rendering the text onto the current page, this commit
replaces the `<a href="#">...</a>` with an `<a>` element that declares
`href="/notes/new"`.

When the system tests are run, our test suite raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'new' could not be found for NotesController
```

[empty-fragment]: https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-the-fragment-identifier
[link_to]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to

---

Declare `GET /notes/new` route

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionController::RoutingError: No route matches [GET] "/notes/new"
```

Declare a [route to respond to `GET /notes/new` HTTP
requests][resources] by routing them to `notes#new`. The `resources`
call is made with the [`only: [:new]` option][only] to exclude all
(actions except for `#new`) routes generated by a bare `resources
:notes` call.

After making this change, the suite raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'new' could not be found for NotesController
```

[resources]: https://guides.rubyonrails.org/v5.2/routing.html#crud-verbs-and-actions
[only]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources-label-Options

---

Declare `app/views/notes/new.html.erb` view

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'new' could not be found for NotesController
```

By declaring a template that corresponds to `notes#new`, we're once
again relying on Rails' default action routing and rendering
conventions.

After introducing the blank template file, we're faced with a familiar
error message:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find field "Message"
    test/system/user_shares_a_message_test.rb:9:in `block in <class:UserSharesAMessageTest>'
```

---

Render `<label>` and `<textarea>`

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find field "Message"
    test/system/user_shares_a_message_test.rb:9:in `block in <class:UserSharesAMessageTest>'
```

When invoked on the [`page`][page] object, [`fill_in`][fill_in],
Capybara will locate the corresponding [`<input type="text">`][input] or
[`<textarea>`][textarea] by resolving the first argument (the `locator`)
by matching its:

* [`[name]`][name] attribute
* [`[id]`][id] attribute
* `Capybara.test_id` attribute
* the text of a [`<label>`][label] element with a [`[for]`][for]
  attribute that references a `<textarea>` or `<input type="text">`

When invoked on an element directly, a missing locator will be resolved
on `self` or a descendant.

This commit renders a `<label>` element with internationalized text, and
a `<textarea>` element that the `<label>` references.

If we want our page to be [accessible] (we *do*), it's important that
every `<form>` field has a corresponding `<label>` associated with it.

Modern browsers can infer a lot of helpful behavior for pages that
render HTML elements with appropriate [semantics], including some
behavior that [improves the accessibility of the content][wcag].

Ensuring that our browser-driven tests interact with the underlying
elements based on `<label>` text improves the odds that the page is
accessible.

Accessibility and leveraging semantics-based behavior aside, system
tests should interact with the page in the same way that end-users
will. Users visiting a page in a web browser won't be interacting with
the page with [CSS selectors][selectors] or HTML attribute, so our tests
shouldn't either.

When run again, the system test raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find link or button "Share"
    test/system/user_shares_a_message_test.rb:10:in `block in <class:UserSharesAMessageTest>'
```

[fill_in]: https://www.rubydoc.info/github/jnicklas/capybara/Capybara/Node/Actions:fill_in
[input]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text
[textarea]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
[page]: https://www.rubydoc.info/github/jnicklas/capybara/Capybara%2FDSL:page
[name]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
[id]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
[label]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
[for]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#Attributes
[accessible]: https://www.w3.org/WAI/fundamentals/accessibility-intro/
[semantics]: https://developer.mozilla.org/en-US/docs/Glossary/semantics#Semantics_in_HTML
[wcag]: https://www.w3.org/TR/WCAG20/
[selectors]: https://developer.mozilla.org/en-US/docs/Learn/CSS/Introduction_to_CSS/Selectors

---

Render `<button>` in `notes#new` template

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find link or button "Share"
    test/system/user_shares_a_message_test.rb:10:in `block in <class:UserSharesAMessageTest>'
```

By declaring a [`button`] element with the text the `click_on` helper
expects, this change addresses the previous test failure and advances
our test _out of_ the [Exercise Phase][exercise] and _into_ the [Verify
Phase][verify].

Our test's assertion is raising a new error:

```
Failure:
UserSharesAMessageTest#test_visiting_the_index [/Users/seanpdoyle/src/prix-fixe/test/system/user_shares_a_message_test.rb:12]:
expected to find text "Hello, World!" in "Message Share"
```

[exercise]: https://thoughtbot.com/blog/four-phase-test#exercise
[verify]: https://thoughtbot.com/blog/four-phase-test#verify

---

Render `<form>` element in `notes#new` template

This commit attempts to resolve the previous error:

```
Failure:
UserSharesAMessageTest#test_visiting_the_index [/Users/seanpdoyle/src/prix-fixe/test/system/user_shares_a_message_test.rb:12]:
expected to find text "Hello, World!" in "Message Share"
```

Our test's assertion that the page contains the contents of our new note
(i.e. `"Hello, World!"`) fails.

The test makes this assertion by invoking [`assert_text`][assert_text].
The failure message's `"Message Share"` is derived by extracting the
text out of our page's `<body>`, ignoring HTML markup.

The change this commit includes (in an effort to advance our test to a
new, different failure) aspires to submit the contents of the page's
`<textarea>` to our server. However, without a `<form>` element
ancestor, our `<textarea>` does not have the means to submit its
contents to our server.

This commit wraps the `<textarea>` and `<button>` in a `<form>` element
that declares [`action="/notes"`][action] and [`method="post"`][method].

The combination of these two attributes results in the `<form>` element
submitting a `POST` HTTP request to the application's `/notes` path. The
intention behind issuing a `POST /notes` request is to adhere to [Rails'
REST-inspired routing convention][routing].

When running the suite again, a new error is raised.

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionController::RoutingError: No route matches [POST] "/notes"
```

[assert_text]: https://www.rubydoc.info/github/teamcapybara/capybara/master/Capybara/Node/Matchers#assert_text-instance_method
[action]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-action
[method]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method
[routing]: https://guides.rubyonrails.org/routing.html#crud-verbs-and-actions

---

Declare a `POST /notes` route

This commit resolves the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionController::RoutingError: No route matches [POST] "/notes"
```

By declaring a `post` route with `"/notes"` as the path, `controller:
"notes`", and `action: "create"`, we configure our router to route
requests to the `notes#create` action.

When we run the test again, it raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'create' could not be found for NotesController
```

---

Declare `notes#create` view template

This commit is in response to the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
AbstractController::ActionNotFound: The action 'create' could not be found for NotesController
```

By creating a view template file that corresponds to the `notes#create`
action, the `NotesController` will render when generating a response.

When we run the test again, it raises a new error:

```
Failure:
UserSharesAMessageTest#test_visiting_the_index [/Users/seanpdoyle/src/prix-fixe/test/system/user_shares_a_message_test.rb:12]:
expected to find text "Hello, World!" in ""
```

---

Render content from `params`

This commit responds to the previous error message:

```
Failure:
UserSharesAMessageTest#test_visiting_the_index [/Users/seanpdoyle/src/prix-fixe/test/system/user_shares_a_message_test.rb:12]:
expected to find text "Hello, World!" in ""
```

In an effort to render the test's `"Hello, World!" String in the
response body, this commit attempts to fetch it from
[`NoteController#params`][params].

The `params` value makes incoming request values available through [a
`Hash`-like interface][strong-params].

In a previous commit, we declared a `<form>` element with a `<textarea>`
element meant to represent a new Note's `content`. This commit attempts
to retrieve that value by invoking `params.fetch(:content)`. The use of
[`#fetch` instead of `#[]` is intentional][fetch], since creating a new
Note will require a `content` value.

When we run the test again, it raises a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionView::Template::Error: param is missing or the value is empty: content
    app/views/notes/create.html.erb:1
```

[params]: https://api.rubyonrails.org/v5.2/classes/ActionController/StrongParameters.html#method-i-params
[strong-params]: https://api.rubyonrails.org/v5.2/classes/ActionController/Parameters.html
[fetch]: https://api.rubyonrails.org/v5.2/classes/ActionController/Parameters.html#method-i-fetch

---

Add `name="content"` to `<textarea>`

This commit is in response to the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
ActionView::Template::Error: param is missing or the value is empty: content
    app/views/notes/create.html.erb:1
```

The `params.fetch(:content)` invocation fails because our `<form>`
element's submission does not transmit the value of its `<textarea>`.

The `<textarea>` element is declared with an `id="content"` attribute
[to instruct the browser to interprets the `<label for="content">`
element as its corresponding label][for]. This attribute is a helpful
declaration to make on the client-side, but does not signal any
information to our server when the `<form>` is submitted.

This commit declares the `<textarea>` with a [`name="content"` attribute
to encode its value as part of the HTTP `POST` request the `<form>`
submits][textarea].

Once this change is made, Rails interprets the HTTP request's body to
contain a value for `content`, which it makes available from `params`.

When we run the test again, it outputs a new message:

```
\# Running:

Capybara starting Puma...
* Version 3.12.1 , codename: Llamas in Pajamas
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:53909
.

Finished in 4.229706s, 0.2364 runs/s, 0.2364 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

In our first Test Driven Development cycle's
[Red-Green-Refactor][tdd-cycle], we've progressed from the Red Phase
(i.e. the test is failing) to the Green Phase (the test is passing).

The test passed! The application's behavior meets the criteria the we've
declared in our system test.

Before considering this feature's work "finished", there is one more
<abbr title="Test Driven Development>TDD</abbr> Phase: Refactoring.

[for]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#attr-for
[textarea]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
[tdd-cycle]: https://www.codecademy.com/articles/tdd-red-green-refactor

---

Enable Request Forgery Protection in `test`

If we're feeling skeptical that the application's behavior _does_ meet
the criteria as defined in our test suite, we can boot it locally and
visit it in a web browser ourselves:

```bash
$ rails server --port 3000
```

Once it's running, we can follow the instructions described in our
system test by opening a web browser and:

* visiting [http://localhost:3000/][]
* clicking on "Share a Note"
* filling in the text box labelled "Message" with the value "Hello,
  World"
* clicking on "Share"

Oh no!

Surprisingly, our server responds to our submission with an error page.

If we inspect our `rails server` process log, it contains the following
output:

```
Started POST "/notes" for ::1 at 2019-05-04 13:37:35 -0400
Processing by NotesController#create as HTML
  Parameters: {"content"=>"Hello, World"}
Can't verify CSRF token authenticity.
Completed 422 Unprocessable Entity in 1ms (ActiveRecord: 0.0ms | Allocations: 461)

ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken):
```

By default, Rails comes with some security-minded default behavior. In
this case, the error's mention of being unable to `verify CSRF token
authenticity` stems from Rails' [Cross Site Request Forgery
Protection][csrf].

The Rails Security Guidelines describe <abbr title="Cross Site Request
Forgery">CSRF</abbr>:

> This attack method works by including malicious code or a link in a
> page that accesses a web application that the user is believed to have
> authenticated. If the session for that web application has not timed
> out, an attacker may execute unauthorized commands.

By default, this protective measure is in place in every [Rails
Environment][rails-env] _except for `test`_.

To ensure that _all_ environments have this protection in place, this
commit [enables CSRF protection in `test.rb`][configuring-controllers].

When we run the test again, it is no longer passing.

It fails with a new error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
DRb::DRbRemoteError: ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)
```

In this instance, regressing from the Green Phase to the Red Phase has a
positive effect. Since our `test` environment's behavior did not have
[parity] with the other environments, a test failure uncovering that
fact is helpful and important to address.

In cases like this that uncover important gaps in behavior, we can
consider transitioning from the Green Phase to Red Phase as a temporary
(but helpful!) detour toward the Refactoring Phase.

[csrf]: https://guides.rubyonrails.org/v5.2/security.html#cross-site-request-forgery-csrf
[rails-env]: https://guides.rubyonrails.org/v5.2/configuring.html#creating-rails-environments
[configuring-controllers]: https://guides.rubyonrails.org/v5.2/configuring.html#configuring-action-controller
[parity]: https://12factor.net/dev-prod-parity

---

Use `form_tag` instead of `<form>`

This commit is in response to the previous error:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
DRb::DRbRemoteError: ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)
```

This commit replaces the hard-coded `<form>` element with a call to
[Rails' `form_tag` view helper][form_tag].

The `form_tag` helper's
interface closely resembles how a `<form>` element is declared. Its
first argument is the path or URL to submit the `<form>` to (which is
otherwise represented as the [`action` attribute][action]). Otherwise,
the rest of the options that `form_tag` accepts correspond to attribute
on the generated `<form>` element.

Most importantly, by using the `form_tag` and passing our `<label>`,
`<textarea>` and `<button>` elements into the `form_tag` invocation's
block, we guarantee that the `<form>` element is generated with an
`<input type="hidden" name="authenticity_token" value="...">` element to
integrate with Rails' CSRF protection.

When we run the test again, it passes:

```
\# Running:

Capybara starting Puma...
* Version 3.12.1 , codename: Llamas in Pajamas
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:55494
.

Finished in 4.141942s, 0.2414 runs/s, 0.2414 assertions/s.
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```

[form_tag]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormTagHelper.html#method-i-form_tag
[action]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-action

---

Render `<form>` with `form_tag` with `form_with`

This commit refactors our application's View code by replacing our
`notes#new` template's call to `form_tag` with a call to
[`form_with`][form_with].

The `form_with` helper's behavior is very similar to the `form_tag`'s.
In addition to generating a CSRF Protection-compliant `<form>` element,
the `form_with` helper will yield an instance of an
[`ActionView::Helpers::FormBuilder`]. This commit doesn't yet make use
of that instance, but its availability will enable future View layer
refactorings.

The `form_with` helper is invoked with the [`local: true`][local] option
to opt-out of submitting form asynchronously through [Rails' Unobtrusive
JavaScript][rails-ujs] (there will be more on that topic in future
commits).

When we run the test again after making this change, it still passes.

[form_with]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormHelper.html#method-i-form_with
[form-builder]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormBuilder.html
[local]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormHelper.html#method-i-form_with-label-form_with+options
[rails-ujs]: https://guides.rubyonrails.org/v5.2/working_with_javascript_in_rails.html#unobtrusive-javascript

---

Build `<textarea>` with `text_area` helper

This commit refactors the View layer's `notes#new` template by replacing
a hard-coded `<textarea>` element with an invocation to
[`text_area`][text_area].

First, we modify the `form_with` call to yield a `FormBuilder` instance
to the block.

Next, we invoke `FormBuilder#text_area` and pass `:content` as the first
argument. This constructs a `<textarea>` element with
[`id="content"`][id] and [`name="content"`][name]. Since our previous
commits depended on both the `id` and `name` attributes' presence, it's
helpful to emphasize that the `FromBuilder#text_area` will generate the
necessary HTML.

When we run the test again, it is still passing.

[id]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-id
[name]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-name
[text_area]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormHelper.html#method-i-text_area

---

Replace `<label>` with `#label` invocation

This commit refactors our View layer's `notes#new` template by replacing
a hard-coded `<label>` element with a call to
[`ActionView::Helpers::FormBuilder#label`][label].

By passing `:content` as the first argument, the generated `<label>`
element's [`for` attribute][for] will declare `for="content"`, which
correspond to the `<textarea>` element's `id="content"` and ensures that
the label corresponds to the form's field.

When we run the test again, it is still passing.

[label]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-label
[for]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#attr-for

---

Replace `<button>` with `#submit` invocation

This commit refactors the View layer's `notes#new` template by replacing
a hard-coded `<button>` element with a call to
[`ActionView::Helpers::FormBuilder#submit`][submit].

When we run the test suite again, it still passes.

[submit]: https://api.rubyonrails.org/classes/ActionView/Helpers/FormTagHelper.html#method-i-submit_tag

---

Use named route in `notes#index`

This commit refactors both our Request Routing and View layer's code to
share helper method.

The `"/notes/new"` String was duplicated in both the `notes#index`
template and our application's route declaration file.

A String value duplicated in this way across disparate files can be
considered a ["magic string"][magic-string], since it's equivalence in
two seemingly unrelated areas of the codebase is both important _and_
unclear.

By declaring the `get "/notes/new"` route declaration with the [`as:
"new_notes"` option][as-option], Rails will generate [`new_notes_path`
and `new_notes_url` routing helpers][helpers] which are made available
within the view layer.

Routing helpers are a discrete list of methods, so attempting to invoke
a route helper that does not exist will raise a `NoMethodError` when
invoked.

When we run the test suite, it passes.

[magic-string]: https://en.wikipedia.org/wiki/Magic_string
[as-option]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-match-label-Options
[helpers]: https://guides.rubyonrails.org/v5.2/routing.html#path-and-url-helpers

---

Replace `"/notes"` with `notes_path` invocation

Similar to the previous commit, this commit refactors the Request
Routing and View layers of our application.

This commit appends an `as: "notes"` option to the `post "/notes"` route
declaration in order to declare `notes_path` and `notes_url` routing
helpers.

Once available, replace our `form_with` invocation's `url: "/notes"`
option with `url: notes_path`.

When we run the test suite, it passes.

---

Replace `post`, `get` declarations with `resources`

This commit refactors the Request Routing layer of our application by
combining our separate `post` and `get` route declarations into a single
[`resources :notes`][resources] call.

The `resources` route helper will generate Rails seven conventional
actions. Our application currently depends on only two of those actions:
`new` and `create`.

By invoking `resources` with the [`only: [:new, :create]` option][only],
the application will exclude all action routes except for `#new` and
`#create`.

After making this change and running the tests again, the suite still
passes.

[resources]: https://guides.rubyonrails.org/v5.2/routing.html#crud-verbs-and-actions
[only]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-resources-label-Options

---

Rename `get "/"` route to "root"

This commit refactors the Request Routing layer of our application to
name the `GET /` route.

By passing `as: "root"` as an option to the `get "/"` declaration, the
routing configuration will declare `root_path` and `root_url` helper
methods that will be available in the application's controllers and view
templates.

When the tests are run again, they're still passing.

---

Replace `get "/"` declaration with `root`

This commit refactors the Request Routing configuration file again.

It replaces the `get "/"` declaration with a call to [`root`][root]. The
`root` call accepts the same arguments as the [`match`][match] routing
helper.

In this case, declaring `controller: "notes"` and `action: "index"` is
all that's necessary to route `GET /` requests to the
`NotesController#index` action.

When the tests are run again, they pass.

[root]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Resources.html#method-i-root
[match]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Mapper/Base.html#method-i-match
[project-card]: https://github.com/seanpdoyle/prix-fixe/projects/1#card-20484715

---

Drive system tests with Headless Chrome Browser

Up until this point, our System Tests have been launching (and opening)
a Chrome instance to run our test.

While debugging test failures, the visualization of a running browser
can make spotting issues easier. However, a separate window flashing
open and closed can be jarring and disruptive.

This commit configures out System tests to be driven by a Chrome browser
running with the `--headless` flag. System Tests will still run within
the context of a Real Browser ™️, but that browser won't be rendered
to the screen.

When debugging issues in the future, [this configuration could be
temporarily reverted][system-test-drivers].

[system-test-drivers]: https://guides.rubyonrails.org/testing.html#changing-the-default-settings

---

Complete the first TDD Red-Green-Refactor Cycle

After finishing this round of refactoring, we can pause and assess the
code related to [original feature][project-card].

Depending on your design preferences or programming practices, there are
more changes that could be made in the name of refactoring.

For the sake of maintaining forward momentum, it now feels like an
appropriate time to consider this feature "ready" to be opened as a pull
request and ultimately merged into the `master` branch.

If you're feeling skeptical this this feature "works" as intended
without any models, database queries, or persistence of any kind, that
skepticism is justified!

One valuable aspect of practicing outside-in testing and <abbr
title="Test Driven Development">TDD</abbr> is that authors can feel
confident that if the tests are well written and passing, the
features are "working" for end-users.

Another aspect of practicing outside-in testing and TDD is that there
will _always_ another test to write. An inevitable outcome of writing
that test is that the implementation will need to be extended to get
that test to pass. We can expect that future features will demand more
from Rails. When its appropriate, we will introduce more concepts and
complexities.

For now, we can be confident that our application behaves exactly in the
one way that we've specified. For now, let's appreciate the simplicity
of our system.

With that in mind, it's time to move onto the next feature.

N.B.
---

In previous commits, this features' test-driven development steps have
been thoroughly documented at a very granular level.

Future features will be test-driven, and those tests and their
corresponding implementation changes will be introduced into the
codebase through a similar process.

For the sake of the reader, subsequent test-driven development steps and
Red-Green-Refactor Cycles may be omitted, undocumented, or combined into
larger and less granular commits.
