### PR TITLE
Discover a note

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -8,8 +8,18 @@ class NotesController < ApplicationController
   end
 
   def create
-    note = Note.create!(params.to_unsafe_h.slice(:content))
+    note = Note.new(note_params)
 
-    redirect_to notes_url
+    if note.save
+      redirect_to notes_url
+    else
+      render(:new, status: :unprocessable_entity)
+    end
+  end
+
+  private
+
+  def note_params
+    params.to_unsafe_h.slice(:content)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -13,13 +13,21 @@ class NotesController < ApplicationController
     if note.save
       redirect_to notes_url
     else
-      render(:new, status: :unprocessable_entity)
+      render(:new, status: :unprocessable_entity, locals: { note: note })
     end
+  end
+
+  def new
+    note = Note.new
+
+    render(locals: {
+      note: note,
+    })
   end
 
   private
 
   def note_params
-    params.to_unsafe_h.slice(:content)
+    params.require(:note).permit(:content)
   end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,4 +6,12 @@ class NotesController < ApplicationController
       notes: notes,
     })
   end
+
+  def create
+    note = Note.create!(params.to_unsafe_h.slice(:content))
+
+    render(locals: {
+      note: note
+    })
+  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,2 +1,9 @@
 class NotesController < ApplicationController
+  def index
+    notes = Note.all
+
+    render(locals: {
+      notes: notes,
+    })
+  end
 end

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -10,8 +10,6 @@ class NotesController < ApplicationController
   def create
     note = Note.create!(params.to_unsafe_h.slice(:content))
 
-    render(locals: {
-      note: note
-    })
+    redirect_to notes_url
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,2 @@
+class Note < ApplicationRecord
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,2 +1,3 @@
 class Note < ApplicationRecord
+  validates :content, presence: true
 end

--- a/app/views/notes/create.html.erb
+++ b/app/views/notes/create.html.erb
@@ -1,1 +1,0 @@
-<%= params.fetch(:content) %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,5 +1,5 @@
 <a href="<%= new_note_path %>">
-  Share a Note
+  <%= translate(".new") %>
 </a>
 
 <ul>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -1,3 +1,7 @@
 <a href="<%= new_note_path %>">
   Share a Note
 </a>
+
+<% Note.all.each do |note| %>
+  <%= note.content %>
+<% end %>

--- a/app/views/notes/index.html.erb
+++ b/app/views/notes/index.html.erb
@@ -2,6 +2,10 @@
   Share a Note
 </a>
 
-<% Note.all.each do |note| %>
-  <%= note.content %>
+<ul>
+<% notes.each do |note| %>
+  <li>
+    <%= note.content %>
+  </li>
 <% end %>
+</ul>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: note, method: :post, local: true) do |form| %>
-  <%= form.label(:content, "Message") %>
+  <%= form.label(:content) %>
   <%= form.text_area(:content) %>
 
-  <%= form.submit("Share") %>
+  <%= form.submit %>
 <% end %>

--- a/app/views/notes/new.html.erb
+++ b/app/views/notes/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: notes_path, method: :post, local: true) do |form| %>
+<%= form_with(model: note, method: :post, local: true) do |form| %>
   <%= form.label(:content, "Message") %>
   <%= form.text_area(:content) %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,5 +44,5 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.action_view.raise_on_missing_translations = true
+  config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = false
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = true
+  config.action_controller.allow_forgery_protection = false
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  notes:
+    index:
+      new: "Share a Note"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,14 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  helpers:
+    label:
+      note:
+        content: "Message"
+    submit:
+      note:
+        create: "Share"
+
   notes:
     index:
       new: "Share a Note"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  resources :notes, only: [:new, :create]
+  resources :notes, only: [:new, :create, :index]
 
-  root controller: "notes", action: "index"
+  root to: redirect("/notes")
 end

--- a/db/migrate/20190506032859_create_notes.rb
+++ b/db/migrate/20190506032859_create_notes.rb
@@ -1,0 +1,9 @@
+class CreateNotes < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notes do |t|
+      t.text :content
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190506032859_create_notes.rb
+++ b/db/migrate/20190506032859_create_notes.rb
@@ -1,7 +1,7 @@
 class CreateNotes < ActiveRecord::Migration[6.0]
   def change
     create_table :notes do |t|
-      t.text :content
+      t.text :content, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,6 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2019_05_06_032859) do
+
+  create_table "notes", force: :cascade do |t|
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,4 +2,12 @@ require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+
+  setup do
+    Rails.configuration.allow_forgery_protection = true
+  end
+
+  teardown do
+    Rails.configuration.allow_forgery_protection = false
+  end
 end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -4,7 +4,7 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   test "#create persists a Note record" do
     content = "Hello, World"
 
-    post notes_path, params: { content: content }
+    post notes_path, params: { note: { content: content } }
 
     assert_equal Note.pluck(:content), [content]
   end
@@ -12,15 +12,15 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   test "#create redirects to /notes" do
     note_attributes = { content: "Hello, World" }
 
-    post notes_path, params: note_attributes
+    post notes_path, params: { note: note_attributes }
 
     assert_redirected_to notes_url
   end
 
   test "#create with invalid data responds with unprocessable entity" do
-    note_attributes = {}
+    note_attributes = { content: "" }
 
-    post notes_path, params: note_attributes
+    post notes_path, params: { note: note_attributes }
 
     assert_response :unprocessable_entity
   end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -10,10 +10,18 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "#create redirects to /notes" do
-    notes_attributes = { content: "Hello, World" }
+    note_attributes = { content: "Hello, World" }
 
-    post notes_path, params: notes_attributes
+    post notes_path, params: note_attributes
 
     assert_redirected_to notes_url
+  end
+
+  test "#create with invalid data responds with unprocessable entity" do
+    note_attributes = {}
+
+    post notes_path, params: note_attributes
+
+    assert_response :unprocessable_entity
   end
 end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -6,7 +6,14 @@ class NotesControllerTest < ActionDispatch::IntegrationTest
 
     post notes_path, params: { content: content }
 
-    assert_response :success
     assert_equal Note.pluck(:content), [content]
+  end
+
+  test "#create redirects to /notes" do
+    notes_attributes = { content: "Hello, World" }
+
+    post notes_path, params: notes_attributes
+
+    assert_redirected_to notes_url
   end
 end

--- a/test/controllers/notes_controller_test.rb
+++ b/test/controllers/notes_controller_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class NotesControllerTest < ActionDispatch::IntegrationTest
+  test "#create persists a Note record" do
+    content = "Hello, World"
+
+    post notes_path, params: { content: content }
+
+    assert_response :success
+    assert_equal Note.pluck(:content), [content]
+  end
+end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NoteTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -7,6 +7,6 @@ class NoteTest < ActiveSupport::TestCase
     valid = note.validate
 
     assert_equal valid, false
-    assert_equal note.errors[:content], [I18n.translate("errors.messages.blank")]
+    assert_equal note.errors[:content], [translate("errors.messages.blank")]
   end
 end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1,11 +1,12 @@
 require 'test_helper'
 
 class NoteTest < ActiveSupport::TestCase
-  test "NOT NULL database constraint on notes.content" do
+  test "validates content is present" do
     note = Note.new
 
-    exercise = -> { note.save! }
+    valid = note.validate
 
-    assert_raises(ActiveRecord::NotNullViolation, /content/, &exercise)
+    assert_equal valid, false
+    assert_equal note.errors[:content], [I18n.translate("errors.messages.blank")]
   end
 end

--- a/test/models/note_test.rb
+++ b/test/models/note_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class NoteTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "NOT NULL database constraint on notes.content" do
+    note = Note.new
+
+    exercise = -> { note.save! }
+
+    assert_raises(ActiveRecord::NotNullViolation, /content/, &exercise)
+  end
 end

--- a/test/system/user_discovers_a_note_test.rb
+++ b/test/system/user_discovers_a_note_test.rb
@@ -1,0 +1,12 @@
+require "application_system_test_case"
+
+class UserDiscoversANoteTest < ApplicationSystemTestCase
+  test "from the root" do
+    content = "Hello, World"
+    Note.create!(content: content)
+
+    visit notes_path
+
+    assert_text content
+  end
+end

--- a/test/system/user_shares_a_message_test.rb
+++ b/test/system/user_shares_a_message_test.rb
@@ -5,7 +5,7 @@ class UserSharesAMessageTest < ApplicationSystemTestCase
     content = "Hello, World!"
 
     visit root_path
-    click_on "Share a Note"
+    click_on translate("notes.index.new")
     fill_in "Message", with: content
     click_on "Share"
 

--- a/test/system/user_shares_a_message_test.rb
+++ b/test/system/user_shares_a_message_test.rb
@@ -6,8 +6,8 @@ class UserSharesAMessageTest < ApplicationSystemTestCase
 
     visit root_path
     click_on translate("notes.index.new")
-    fill_in "Message", with: content
-    click_on "Share"
+    fill_in translate("helpers.label.note.content"), with: content
+    click_on translate("helpers.submit.note.create")
 
     assert_text content
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@ require_relative '../config/environment'
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
+  include ActionView::Helpers::TranslationHelper
+
   # Run tests in parallel with specified workers
   parallelize(workers: :number_of_processors)
 


### PR DESCRIPTION
Replace root with Redirect to `/notes`
---

The previous route declaration configures our application to handle
requests to `/` with the `notes#index` controller action.

This behaved as specified by our system tests that exercise the
application by visiting `/` directly.

Our application declares a `notes#index` view template, which our
`NotesController#index` implicitly renders.

This approach adheres to conventional Rails patterns. However, without a
corresponding `:index` declaration in our `resources :notes`'s `only:`
key, our application won't generate a `notes_path` routing helper.

Our application redirects responses to the `/` path instead of what
could be the `/notes` path.

This commit reconfigures the `root` route declaration to [redirect `/`
requests to `/notes`][redirect], and adds `:index` to the list of
supported `NotesController` actions.

[redirect]: https://api.rubyonrails.org/v5.2/classes/ActionDispatch/Routing/Redirection.html#method-i-redirect

Add failing system test
---

[Card][]:

When I have spare time,
I want to know what others think,
So that I can learn

---

This commit declares a system test that specifies that visiting the
application's root path (i.e. `GET /`) will render the content of
already existing Note records.

The test's Setup Phase invokes the [`Note.create!`][create!] with the
intention of creating a row in the `notes` database table.

Up until this point in the process, we've referred to the concept of our
application's shared messages as "notes". Choosing "note" as our domain
term is inspired by the [W3C ActivityPub Specification][activitypub].
Specifically, the [Mastodon Federated Social Networking
Platform][mastodon] exclusively supports [Activities of type
"Note"][note].

The `notes` database table does not yet exist, and neither does the
class that defines the `ActiveRecord`-backed `Note` model.

When the test is executed, it fails:

```
Error:
UserDiscoversANoteTest#test_from_the_root:
NameError: uninitialized constant UserDiscoversANoteTest::Note
    test/system/user_discovers_a_note_test.rb:5:in `block in <class:UserDiscoversANoteTest>'
```

This failure message communicates the fact that we have not yet codified
the concept of a "note" in our application's domain models.

[Card]: https://github.com/seanpdoyle/prix-fixe/projects/1#card-20484812
[create!]: https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create-21
[activitypub]: https://www.w3.org/TR/activitypub/#create-activity-outbox
[mastodon]: https://mastodon.social
[note]: https://docs.joinmastodon.org/development/activitypub/#activities
[mastodon]: https://docs.joinmastodon.org/development/activitypub/#activities

Generate `Note` model
---

This commit resolves the previous error:

```
Error:
UserDiscoversANoteTest#test_from_the_root:
NameError: uninitialized constant UserDiscoversANoteTest::Note
    test/system/user_discovers_a_note_test.rb:5:in `block in <class:UserDiscoversANoteTest>'
```

The contents of this diff were generated by running Rails' model
generator:

```bash
$ rails generate model note content:text
```

Rails' model generator supports numerous different options and flags.
Running the following command provides helpful documentation about the
command line interface:

```bash
$ rails generate model --help
```

---

```
Usage:
  rails generate model NAME [field[:type][:index] field[:type][:index]] [options]

Options:
      [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
      [--force-plural], [--no-force-plural]      # Forces the use of the given model name
  -o, --orm=NAME                                 # ORM to be invoked
                                                \# Default: active_record

ActiveRecord options:
      [--migration], [--no-migration]        # Indicates when to generate migration
                                            \# Default: true
      [--timestamps], [--no-timestamps]      # Indicates when to generate timestamps
                                            \# Default: true
      [--parent=PARENT]                      # The parent class for the generated model
      [--indexes], [--no-indexes]            # Add indexes for references and belongs_to columns
                                            \# Default: true
      [--primary-key-type=PRIMARY_KEY_TYPE]  # The type for primary key
  db, [--database=DATABASE]                  # The database for your model's migration. By default, the current environment's primary database is used.
  -t, [--test-framework=NAME]                # Test framework to be invoked
                                            \# Default: test_unit

TestUnit options:
      [--fixture], [--no-fixture]   # Indicates when to generate fixture
                                    \# Default: true
  -r, [--fixture-replacement=NAME]  # Fixture replacement to be invoked

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Stubs out a new model. Pass the model name, either CamelCased or
    under_scored, and an optional list of attribute pairs as arguments.

    Attribute pairs are field:type arguments specifying the
    model's attributes. Timestamps are added by default, so you don't have to
    specify them by hand as 'created_at:datetime updated_at:datetime'.

    As a special case, specifying 'password:digest' will generate a
    password_digest field of string type, and configure your generated model and
    tests for use with Active Model has_secure_password (assuming the default ORM
    and test framework are being used).

    You don't have to think up every attribute up front, but it helps to
    sketch out a few so you can start working with the model immediately.

    This generator invokes your configured ORM and test framework, which
    defaults to Active Record and TestUnit.

    Finally, if --parent option is given, it's used as superclass of the
    created model. This allows you create Single Table Inheritance models.

    If you pass a namespaced model name (e.g. admin/account or Admin::Account)
    then the generator will create a module with a table_name_prefix method
    to prefix the model's table name with the module name (e.g. admin_accounts)

Available field types:

    Just after the field name you can specify a type like text or boolean.
    It will generate the column with the associated SQL type. For instance:

        `rails generate model post title:string body:text`

    will generate a title column with a varchar type and a body column with a text
    type. If no type is specified the string type will be used by default.
    You can use the following types:

        integer
        primary_key
        decimal
        float
        boolean
        binary
        string
        text
        date
        time
        datetime

    You can also consider `references` as a kind of type. For instance, if you run:

        `rails generate model photo title:string album:references`

    It will generate an `album_id` column. You should generate these kinds of fields when
    you will use a `belongs_to` association, for instance. `references` also supports
    polymorphism, you can enable polymorphism like this:

        `rails generate model product supplier:references{polymorphic}`

    For integer, string, text and binary fields, an integer in curly braces will
    be set as the limit:

        `rails generate model user pseudo:string{30}`

    For decimal, two integers separated by a comma in curly braces will be used
    for precision and scale:

        `rails generate model product 'price:decimal{10,2}'`

    You can add a `:uniq` or `:index` suffix for unique or standard indexes
    respectively:

        `rails generate model user pseudo:string:uniq`
        `rails generate model user pseudo:string:index`

    You can combine any single curly brace option with the index options:

        `rails generate model user username:string{30}:uniq`
        `rails generate model product supplier:references{polymorphic}:index`

    If you require a `password_digest` string column for use with
    has_secure_password, you can specify `password:digest`:

        `rails generate model user password:digest`

    If you require a `token` string column for use with
    has_secure_token, you can specify `auth_token:token`:

        `rails generate model user auth_token:token`

Examples:
    `rails generate model account`

        For Active Record and TestUnit it creates:

            Model:      app/models/account.rb
            Test:       test/models/account_test.rb
            Fixtures:   test/fixtures/accounts.yml
            Migration:  db/migrate/XXX_create_accounts.rb

    `rails generate model post title:string body:text published:boolean`

        Creates a Post model with a string title, text body, and published flag.

    `rails generate model admin/account`

        For Active Record and TestUnit it creates:

            Module:     app/models/admin.rb
            Model:      app/models/admin/account.rb
            Test:       test/models/admin/account_test.rb
            Fixtures:   test/fixtures/admin/accounts.yml
            Migration:  db/migrate/XXX_create_admin_accounts.rb
```

Unfortunately, after running this command, our test suite no longer
runs. We're prompted with the following error:

```
Migrations are pending. To resolve this issue, run:

        rails db:migrate RAILS_ENV=test

```

We've declared our model class. We've declared a new [ActiveRecord
database migration][migration]. We haven't yet modified our local test
database to make the schema changes proposed in our migration.

[migration]: https://guides.rubyonrails.org/v5.2/active_record_migrations.html

Run the `create_notes` migration
---

This commit resolves the previous error:

```
Migrations are pending. To resolve this issue, run:

        rails db:migrate RAILS_ENV=test
```

Before running the suggested command, this commit introduces a [`NOT
NULL` database constraint][constraint] to the `notes.content` column,
preventing it from accepting `NULL` values. It's important to make this
modification to the generated migration _before_ executing the
migration.

To do so, this commit adds a [`null: false` option] to the
[`Table#text`][text] declaration, then runs the migration:

```bash
$ rails db:migrate
```

To ensure that our `NOT NULL` database constraint is enforced, this
commit introduces our first model test.

When we execute the test, it passes:

```bash
$ rails test test/models/note_test.rb
```

When our system tests are re-run, there is a new error:

```
Failure:
  UserDiscoversANoteTest#test_from_the_root [/Users/seanpdoyle/src/prix-fixe/test/system/user_discovers_a_note_test.rb:9]:
  expected to find text "Hello, World" in "Share a Note"
```

[constraint]: https://www.w3schools.com/sql/sql_notnull.asp
[text]: https://api.rubyonrails.org/v5.2/classes/ActiveRecord/ConnectionAdapters/Table.html

Render a list of all `Note` records `notes#index`
---

This commit addresses the previous error:

```
Failure:
  UserDiscoversANoteTest#test_from_the_root [/Users/seanpdoyle/src/prix-fixe/test/system/user_discovers_a_note_test.rb:9]:
  expected to find text "Hello, World" in "Share a Note"
```

By iterating over the collection returned by a `Note.all` invocation to
our `notes#index` template, our application renders the `#content` into
our response' HTML.

This "solution" addresses the immediate failure message in a minimal and
simple way.

When our system test is executed, it passes.

Render `notes#index` from controller action
---

This commit refactors the `notes#index` template, extracting the
`Note.all` record retrieval logic into the controller.

The `NotesController#index` action invokes [`render` with the
`locals`][render] option to declare variables available as
template-local variables.

Most Rails template rendering documentation suggests that controllers
pass references to templates by [declaring and sharing instance
variables][instance-variables].

This commit deviates from that convention by explicitly passing the
`notes` controller-local variable to the view template through as a
`notes:` key in the `locals` hash.

By being explicit about which variables our templates can access, our
templates' data dependencies are more apparent and discoverable. Instead
of being unsure about which controller declares which instance variable,
we can inspect the `render` call that invoked the view and see an
exhaustive list of the variables that are available.

When we re-run the system tests, they're still passing.

[render]: https://guides.rubyonrails.org/v5.2/layouts_and_rendering.html#passing-local-variables
[instance-variables]: https://api.rubyonrails.org/v5.2/classes/ActionView/Base.html

Introduce `NotesController` tests
---

While the test suite is passing, there is an opportunity to drive
improve the existing features and increase our system's overall test
coverage.

While implementing the [project's first feature][feature], we didn't
have a `Note` model, so we couldn't interact with our system's database.

To work within that constraint, our system accepted `POST /notes` HTTP
requests and responded with HTML that rendered the request body's
`content` value.

Now that we've introduced a `Note` model and have a `notes` table in our
database, we can extend our existing behavior to also persist the
`content` submitted in `POST /notes` requests.

This commit introduces our first integration test to add test coverage
for our `NotesController`. The file contains a test to ensure
that the submitted data is persisted as a row in the `notes` table.

When we execute the new test, it raises a configuration error:

```
Error:
  NotesControllerTest#test_#create_persists_a_Note_record:
  DRb::DRbRemoteError: ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)
  test/controllers/notes_controller_test.rb|7| in `block in <class:NotesControllerTest>'
```

[feature]: https://github.com/seanpdoyle/prix-fixe/issues/2

Disable CSRF-protection when in `test` environment
---

This commit addresses the previous error:

```
Error:
  NotesControllerTest#test_#create_persists_a_Note_record:
  DRb::DRbRemoteError: ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)
  test/controllers/notes_controller_test.rb|7| in `block in <class:NotesControllerTest>'
```

This error message is related to the fact that our controller tests are
making `POST` requests to our server without a valid [Cross-Site Request
Forgery Protection authenticity token][csrf]. [In a previous
commit][e2a17db], we modified the Rails `test` environment default value
so that our system tests would require a valid token.

That change was made so that our tests could be strict about the
contents of our page's `<form>` elements. Since our system tests
exercise our system in a way that is most similar to our end-users,
being strict about security measures is important.

On the other hand, our controller tests interact with our application
strictly through HTTP requests, one layer of abstraction removed from a
web browser. With this in mind, returning to the Rails-provided defaults
feels like an appropriate trade-off between security and test-code
clarity and simplicity.

To account for that, this commit also adds [`setup` and `teardown`
hooks][hooks] to our `ApplicationSystemTestCase` to toggle
CSRF-protection on for system tests.

With those configuration changes in-place, our system tests are still
passing, and our controller tests are raising more actionable error
messages:

```
Failure:
NotesControllerTest#test_#create_persists_a_Note_record [test/controllers/notes_controller_test.rb:10]:
Expected: []
  Actual: ["Hello, World"]
```

[csrf]: https://guides.rubyonrails.org/v5.2/security.html#cross-site-request-forgery-csrf
[e2a17db]: https://github.com/seanpdoyle/prix-fixe/commit/e2a17db8da0d5caf61f06d2aaa7d7082bc765c11
[hooks]: https://api.rubyonrails.org/v5.2/classes/ActiveSupport/Testing/SetupAndTeardown.html

Persist data in `POST /notes` requests to `notes`
---

This commit addresses the previous error:

```
Failure:
NotesControllerTest#test_#create_persists_a_Note_record [test/controllers/notes_controller_test.rb:10]:
Expected: []
  Actual: ["Hello, World"]
```

This error message occurs because our assertion that the `notes` table
will include a row with `"Hello, World"` as the value of the `content`
column is failing.

To resolve this error, our controller calls [`Note.create!`][create!]
with the contents of the HTTP request body, available to the controller
action through the [`params`][params] helper method. Our test's `POST
/notes` request's body specifies the content under the `content` key, so
passing [`params.slice(:content)`][slice] to the `.create!` call will
pass along the value of the `content` from our request as the value of
the `Note` model's `content` attribute.

Without the intermediate call to
[`ActionController::Parameters#to_unsafe_h`][to_unsafe_h], our tests
error:

```
Error:
NotesControllerTest#test_#create_persists_a_Note_record:
ActiveModel::ForbiddenAttributesError: ActiveModel::ForbiddenAttributesError
    app/controllers/notes_controller.rb:11:in `create'
    test/controllers/notes_controller_test.rb:7:in `block in <class:NotesControllerTest>'
```

It turns out that [Strong Parameters][params] expects the body of
incoming `POST` requests to have a certain shape. The way that our
application is submitting `<form>` submissions does not comply to that
shape.

For now, coercing `params` _from_ an instance of
`ActionController::Parameters` _to_ an instance of
[`ActiveSupport::HashWithIndifferentAccess`][hash_with_indifferent_access]
is a trade-off work making so that we can return our tests to their
originally passing state. Once we're back to being in the Green Phase of
our TDD cycle, we can correct this security circumvention.

When we re-run our controller tests, they pass.

[create!]: https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Persistence/ClassMethods.html#method-i-create-21
[params]: https://api.rubyonrails.org/v5.2/classes/ActionController/StrongParameters.html
[slice]: https://ruby-doc.org/core-2.6.1/Hash.html#method-i-slice
[to_unsafe_h]: https://api.rubyonrails.org/v5.2/classes/ActionController/Parameters.html#method-i-to_unsafe_h
[hash_with_indifferent_access]: https://api.rubyonrails.org/v5.2/classes/ActiveSupport/HashWithIndifferentAccess.html

Redirect to `/notes` after `POST /notes` requests
---

This commit modifies our `NotesController#create` action's behavior.
Instead of rendering a `create.html.erb` template, respond by
redirecting the client to the `notes#index` route.

Since we're redirecting away from the `notes#create` action, this commit
removes the `notes/create.html.erb` template.

Validate presence of `notes.content`
---

This commit adds both model and controller coverage for validating that
`Note` model is created with its required fields.

Extends the `Note` model to use the
[`validates_presence_of`][validates_presence_of] validator by [passing
`presence: true` to the `validates` macro][validates].

When validating a record without a `content` field, the `presence: true`
validation's failure supersedes the previous behavior of violating the
column's `NOT NULL` constraint and raising a
`ActiveRecord::NotNullViolation` error. Since the two are not
compatible, this commit removes the previous test coverage from
`notes_test.rb`.

When responding to a `POST /notes` request that would result in an
invalid `Note` record, our controller will re-render the `notes#new` to
present the client with another opportunity to submit a Note. In
addition, the controller will respond with a [422 HTTP Status][422] to
indicate to the client that the previous request was unprocessable
entity.

[validates_presence_of]: https://api.rubyonrails.org/v5.2/classes/ActiveRecord/Validations/ClassMethods.html#method-i-validates_presence_of
[validates]: https://api.rubyonrails.org/v5.2/classes/ActiveModel/Validations/ClassMethods.html#method-i-validates
[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422

Pass `model:` instead of `url:` in `notes#new`
---

After the previous commit, an invalid submission to the `notes#create`
action results in a re-rendering of the `notes#new` template. When
re-rendering the `notes#new` template, the controller could pass a
reference to the invalid `Note` instance to pre-populate the `<form>`
element's fields with the previously submitted values.

Unfortunately, the `<form>` element in the `notes#new` template doesn't
use a reference to a `Note` instance at all. Instead, [it passes a value
for the `url:` key to the `form_with` helper][form_with]. When the
`url:` key is replaced with a `model:` key that references an instance
of `Note`, the structure of the request body submitted to `POST /notes`.

Instead of the [`FormBuilder`][form-builder] building a `<textarea>`
element with `name="content"`, a `form_with` passed a `model:` reference
uses the [`Note.model_name`][model_name] to namespace the `name`
attribute with `note`, and renders `<textarea name="note[content]">`.

When the server responds to a `POST /notes` request submitted by such a
`<form>`, the values are nested within a key of that namespace.

In our case, `<textarea name="note[content]">` results in
[`strong_params`][strong_params]-compliant
`params` helper that can access the `content` value by chaining
[`#require`][require] and [`#permit`][permit]:

```rb
params.require(:note).permit(:content)
```

[form_with]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormHelper.html#method-i-form_with
[form-builder]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormBuilder.html
[model_name]: https://api.rubyonrails.org/v5.2/classes/ActiveModel/Naming.html#method-i-model_name
[strong_params]: https://api.rubyonrails.org/v5.2/classes/ActionController/StrongParameters.html
[require]: https://api.rubyonrails.org/v5.2/classes/ActionController/Parameters.html#method-i-require
[permit]: https://api.rubyonrails.org/v5.2/classes/ActionController/Parameters.html#method-i-permit

Internationalize application's text
---

When the `UserSharesAMessageTest` internationalizes the test step to
click on an `<a>` element that contains the text `Share a Note` with
[`I18n.translate("notes.index.new")`][i18n-translate], the following
error is raised:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
Capybara::ElementNotFound: Unable to find link or button "translation missing: en.notes.index.new"
    test/system/user_shares_a_message_test.rb:8:in `block in <class:UserSharesAMessageTest>'
```

The key, `notes.index.new` was selected intentionally. The `notes`
portion corresponds to the `notes` controller's internationalization
namespace. The `index` portion corresponds to the `NotesController`'s
`index` action. The `new` portion is arbitrary, but represents the text
that will be rendered into an `<a>` element linking to the `notes#new`
route.

Capybara raises this error stating that the text `"translation missing:
en.notes.index.new"` is not present on the server-generated page. The
`en` portion prefixing the rest of the internationalization key is
derived from the request's current locale (i.e. English). This error is
not particularly helpful in driving our next code change: rendering
`"translation missing: en.notes.index.new"` on the page is not a desired
behavior.

The text `"translation missing: en.notes.index.new"` comes from [Rails'
flexible, forgiving default translation behavior][missing] while in
`development` and `test` environments.

This commit changes that default behavior.

First, it replaces the test's call to `I18n.translate` with calls to
`ActionView::Helpers::TranslationHelper#translate`.

Next, by un-commenting the lines in `config/environments/test.rb` (and
`config/environments/development.rb` for test/development parity) and
ensuring that our test suite internationalizes text with the same
[`translate` that `ActionView` uses][action-view-translate], a newer and
more helpful error message is raised:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
I18n::MissingTranslationData: translation missing: en.notes.index.new
    test/system/user_shares_a_message_test.rb:8:in `block in <class:UserSharesAMessageTest>'
```

When that key is declared within the `config/locales/en.yml` file, the
test passes.

Finally, this commit replaces the `Share a Note` text that is hard-coded
in the `notes/index.html.erb` template with a call to `translate`.

By rendering `<%= translate(".new") %>` in the `notes#index` view
template, Rails will resolve the `.new` internationalization key
relative the current "context", which is a request to `notes#index`.

[The context is translated into an internationalization scope][scope]:
`notes.index`. This internationalization scope is prepended to the
relative `.new` key, which is then prepended with the current locale of
`en`.

This process generates a fully-qualified internationalization key of
`en.notes.index.new`, which corresponds to the translation we declared
in our test.

[missing]: https://guides.rubyonrails.org/i18n.html#abstracting-localized-code
[i18n-translate]: https://github.com/ruby-i18n/i18n/tree/529b83a32036c210e4e35d49a2ac23e956cca67a#rails
[action-view-translate]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/TranslationHelper.html#method-i-translate
[scope]: https://api.rubyonrails.org/classes/v5.2/ActionView/Helpers/TranslationHelper.html#method-i-translate

Use `FormBuilder` to internationalize labels
---

When the system test is modified to `translate` other keys, the test
fails:

```
Error:
UserSharesAMessageTest#test_visiting_the_index:
I18n::MissingTranslationData: translation missing: en.helpers.label.note.content
    test/system/user_shares_a_message_test.rb:9:in `block in <class:UserSharesAMessageTest>'
```

The key structure for this value is not arbitrary: it adheres to the
conventions for Rails' [`ActionView::Helpers::FormBuilder#label`][label]
resolution API.

When we declare the corresponding internationalization keys, the system
tests pass.

Finally, we can remove the `String` arguments from the `notes#new`
template's helper method calls to rely on the internationalization
behavior.

[label]: https://api.rubyonrails.org/v5.2/classes/ActionView/Helpers/FormBuilder.html#method-i-label
